### PR TITLE
(fix) generate() output aligns with original transformers

### DIFF
--- a/examples/llama/generate.py
+++ b/examples/llama/generate.py
@@ -43,6 +43,7 @@ def run_llama3_generate(args):
             input_kwargs["input_ids"] = input_ids
 
         output_ids = model.generate(**input_kwargs, use_cache=args.use_cache, max_new_tokens=30, do_sample=False)
+        output_ids = [out_ids[len(in_ids) :] for in_ids, out_ids in zip(input_ids, output_ids)]
         output_ids = output_ids.asnumpy()
 
         outputs = tokenizer.batch_decode(output_ids, skip_special_tokens=True)[0].strip()

--- a/examples/qwen/generate.py
+++ b/examples/qwen/generate.py
@@ -40,6 +40,7 @@ def run_qwen2_generate(args):
         input_kwargs["input_ids"] = input_ids
 
         output_ids = model.generate(**input_kwargs, use_cache=args.use_cache, max_new_tokens=512, do_sample=False)
+        output_ids = [out_ids[len(in_ids) :] for in_ids, out_ids in zip(input_ids, output_ids)]
         output_ids = output_ids.asnumpy()
 
         outputs = tokenizer.batch_decode(output_ids, skip_special_tokens=True)[0].strip()

--- a/examples/qwen2_vl/test_vqa.py
+++ b/examples/qwen2_vl/test_vqa.py
@@ -154,6 +154,9 @@ print(f"generated_ids length / #steps: {len(generated_ids[0])}")
 elapsed = time.time() - start_time
 print("Average speed %.4fs/step" % (elapsed / len(generated_ids[0])))
 
+generated_ids = [
+    output_ids[len(input_ids):] for input_ids, output_ids in zip(inputs.input_ids, generated_ids)
+]
 output_text = processor.batch_decode(generated_ids, skip_special_tokens=True, clean_up_tokenization_spaces=False)[0]
 
 print("Generated response, time elapsed: %.4fs" % (time.time() - start_time))

--- a/examples/qwen2_vl/video_understanding.py
+++ b/examples/qwen2_vl/video_understanding.py
@@ -97,6 +97,9 @@ for video_path in CLIPS:
     elapsed = time.time() - start_time
     print("Average speed %.4fs/step" % (elapsed / len(generated_ids[0])))
 
+    generated_ids = [
+        output_ids[len(input_ids):] for input_ids, output_ids in zip(inputs.input_ids, generated_ids)
+    ]
     output_text = processor.batch_decode(generated_ids, skip_special_tokens=True, clean_up_tokenization_spaces=False)[0]
 
     print("Generated response, time elapsed: %.4fs" % (time.time() - start_time))

--- a/mindway/transformers/generation/utils.py
+++ b/mindway/transformers/generation/utils.py
@@ -1729,9 +1729,6 @@ class GenerationMixin:
                 **model_kwargs,
             )
 
-            # 14. unlike the original transformers, need delete the length of the input
-            result = result[:, inputs_tensor.shape[1] :]
-
         elif generation_mode in (GenerationMode.BEAM_SAMPLE, GenerationMode.BEAM_SEARCH):
             raise NotImplementedError
         elif generation_mode == GenerationMode.GROUP_BEAM_SEARCH:


### PR DESCRIPTION
**Fix:**
1. generate() output keep input tensors:  `mindway/transformers/generation/utils.py`
2. generate() usage examples: delete input ids as final generated ids
   - `examples/llama/qwen/qwen2-vl`
 
@Mark-ZhouWX 